### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -1,3 +1,5 @@
+permissions:
+  contents: read
 name: Android CI
 
 on:


### PR DESCRIPTION
Potential fix for [https://github.com/OpenSourceTestApp/testapp/security/code-scanning/1](https://github.com/OpenSourceTestApp/testapp/security/code-scanning/1)

To fix the problem, add a `permissions` block to the workflow or to the specific job(s) that limits the `GITHUB_TOKEN` to the least privilege required. In this case, the workflow appears to only need to read repository contents (for actions like `actions/checkout`), and does not perform any write operations (such as creating issues, pushing code, or modifying pull requests). Therefore, setting `permissions: contents: read` at the workflow level is sufficient and safest. This should be added near the top of the file, after the `name` and before the `on` block, to apply to all jobs in the workflow.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
